### PR TITLE
fix: aligned block selection, when we have text next to it

### DIFF
--- a/src/styles.less
+++ b/src/styles.less
@@ -153,10 +153,6 @@
 //   text-align: inherit;
 // }
 
-.block.align {
-  z-index: auto !important;
-}
-
 /* Demo styles */
 .green-demo-box {
   padding: 1em;


### PR DESCRIPTION
Remove z-index definition, which overwrote the original z-index, meaning the block could not be selected.

fixes #100